### PR TITLE
update manager so it can handle Dependency injection

### DIFF
--- a/model_controller/managers.py
+++ b/model_controller/managers.py
@@ -11,7 +11,7 @@ class SoftDeletionManager(models.Manager):
         super(SoftDeletionManager, self).__init__(*args, **kwargs)
 
     def get_queryset(self):
-        qs = super().get_queryset()
+        qs = super(SoftDeletionManager, self).get_queryset()
 
         if self.alive_only:
             qs = qs.filter(alive=True)

--- a/model_controller/managers.py
+++ b/model_controller/managers.py
@@ -11,9 +11,14 @@ class SoftDeletionManager(models.Manager):
         super(SoftDeletionManager, self).__init__(*args, **kwargs)
 
     def get_queryset(self):
+        qs = super().get_queryset()
+
         if self.alive_only:
-            return SoftDeletionQuerySet(self.model).alive()
-        return SoftDeletionQuerySet(self.model)
+            qs = qs.filter(alive=True)
+
+        if not issubclass(qs.__class__, SoftDeletionQuerySet):
+            qs.__class__ = SoftDeletionQuerySet
+        return qs
 
     def hard_delete(self):
         return self.get_queryset().hard_delete()


### PR DESCRIPTION
This change is for model that have multiple managers class
So you can chain the get_queryset method by calling super()

for example if you have the manager that filter alive = true  (SoftDeletionManager)
and something = true (SomethingManager)

You can use  it as 

```python
class SoftDeleteSomethingManager(SoftDeletionManager, SomethingManager):
     pass
```

